### PR TITLE
Added how to install section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ We have created a fork of PDF Images from http://sourceforge.net/projects/pdf-im
 
 We needed the functionality of pdfimages from Popplerbecause we needed an command line method to export objects with transparency from InDesign CS4 to a PNG bitmap. We export single image objects from InDesign to a PDF with Acrobat version 8. We then use the PDF-Images app to extract the images. If there is only one image, this has no alpha channel, else we use convert to combine these images to a new bitmap with an alpha channel.
 
+
+## Installation
+
+It is possible to use Homebrew for installation since `pdfimages` is available in `poppler` package.
+
+```
+brew install poppler
+```
+
 ## Usage
 
 PDF-Images for Cocoa with cli


### PR DESCRIPTION
Although there is a (closed) issue for installation instructions, I think it would be nice to have it right on the readme page.